### PR TITLE
Feature/fees

### DIFF
--- a/src/lib/backtest.ts
+++ b/src/lib/backtest.ts
@@ -140,7 +140,7 @@ export function backtest<InputBarT extends IBar, IndicatorBarT extends InputBarT
     //
     // Sum of maker fee and taker fee.
     //
-    const fees = strategy.fees() || 0;
+    const fees = strategy.fees && strategy.fees() || 0;
 
     //
     // Tracks trades that have been closed.

--- a/src/lib/strategy.ts
+++ b/src/lib/strategy.ts
@@ -87,6 +87,12 @@ export interface IOpenPositionRuleArgs<BarT extends IBar, ParametersT> extends I
 }
 
 /**
+ * Computes the fees.
+ * Return the sum of maker fee and taker fee.
+ */
+export type FeesFn = () => number;
+
+/**
  * Arguments to a stop loss rule function.
  */
 export interface IStopLossArgs<BarT extends IBar, ParametersT> extends IOpenPositionRuleArgs<BarT, ParametersT> {
@@ -208,4 +214,10 @@ export interface IStrategy<InputBarT extends IBar = IBar, IndicatorsBarT extends
      * Return the amount of profit to trigger an exit.
      */
     profitTarget?: ProfitTargetFn<InputBarT, ParametersT>;
+
+    /**
+     * Function that computes the fees
+     * Return the sum of maker fee and taker fee.
+     */
+    fees: FeesFn;
 }

--- a/src/lib/strategy.ts
+++ b/src/lib/strategy.ts
@@ -219,5 +219,5 @@ export interface IStrategy<InputBarT extends IBar = IBar, IndicatorsBarT extends
      * Function that computes the fees
      * Return the sum of maker fee and taker fee.
      */
-    fees: FeesFn;
+    fees?: FeesFn;
 }


### PR DESCRIPTION
I added a simple fee to backtest trading.
This is because adding a fee will affect the analysis results.

It is used in strategy like this:

maker fee => -0.01%
taker fee => 0.075%

```js
// strategy
.
.
.

fees: () => {
    return (0.05 / 100) + (-0.01 / 100)
}
.
.


```